### PR TITLE
feat(kubernetes): ensure PVC is bound before pod creation and expand security context

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -489,6 +489,21 @@ type = "noop"
 # Run the runtime sandbox container in privileged mode for use with docker-in-docker
 #privileged = false
 
+# Allow processes in the runtime sandbox container to escalate privileges
+#allow_privilege_escalation = false
+
+# Mount the runtime sandbox container root filesystem as read-only
+#read_only_root_filesystem = false
+
+# Require the runtime sandbox container to run as a non-root user
+#run_as_non_root = true
+
+# Override the user ID used for the runtime sandbox container
+#run_as_user = 1000
+
+# Override the primary group ID used for the runtime sandbox container
+#run_as_group = 1000
+
 #################################### Model Routing ############################
 # Configuration for experimental model routing feature
 # Enables intelligent switching between different LLM models for specific purposes

--- a/openhands/core/config/kubernetes_config.py
+++ b/openhands/core/config/kubernetes_config.py
@@ -61,6 +61,26 @@ class KubernetesConfig(BaseModel):
         default=False,
         description='Run the runtime sandbox container in privileged mode for use with docker-in-docker',
     )
+    allow_privilege_escalation: bool | None = Field(
+        default=None,
+        description='Allow processes in the runtime sandbox container to escalate privileges',
+    )
+    read_only_root_filesystem: bool | None = Field(
+        default=None,
+        description='Mount the runtime sandbox container root filesystem as read-only',
+    )
+    run_as_non_root: bool | None = Field(
+        default=None,
+        description='Require the runtime sandbox container to run as a non-root user',
+    )
+    run_as_user: int | None = Field(
+        default=None,
+        description='Override the user ID used for the runtime sandbox container',
+    )
+    run_as_group: int | None = Field(
+        default=None,
+        description='Override the primary group ID used for the runtime sandbox container',
+    )
 
     model_config = ConfigDict(extra='forbid')
 


### PR DESCRIPTION
## Summary
- wait for persistent volume claims to bind before launching runtime pods
- expose additional Kubernetes security context fields (runAsNonRoot, readOnlyRootFilesystem, allowPrivilegeEscalation, runAsUser, runAsGroup)
- document the new Kubernetes security context options in the sample configuration

## Testing
- pytest tests/runtime/test_runtime_resource.py