### PR TITLE
fix: Rename bitbucket config fields and adopt user_id

### DIFF
--- a/docs/usage/configuration-options.mdx
+++ b/docs/usage/configuration-options.mdx
@@ -431,6 +431,41 @@ All security configuration options can be set as environment variables by prefix
   - Default: `""`
   - Description: The security analyzer to use
 
+## Secrets Store and Git Provider Tokens
+
+You can manage long-lived Git credentials in the `[secrets_store.provider_tokens]` section of `config.toml`.
+Each provider (`github`, `gitlab`, `bitbucket`) accepts a table with provider-specific options.
+
+### Bitbucket Provider Token Fields
+
+Configure Bitbucket access by adding a `[secrets_store.provider_tokens.bitbucket]` table.
+All keys are optional unless noted.
+
+- `token`
+  - Type: `str`
+  - Description: Bitbucket credential. Use `username:app_password` for Bitbucket Server or app passwords.
+- `host`
+  - Type: `str`
+  - Default: `"bitbucket.org"`
+  - Description: Custom Bitbucket domain for self-hosted/server instances.
+- `user_id`
+  - Type: `str`
+  - Description: Bitbucket account identifier. For server mode this should match the username or slug portion of your account. If the token is supplied in `username:app_password` format, the username portion is used automatically when `user_id` is omitted.
+- `bitbucket_mode`
+  - Type: `"cloud" | "server"`
+  - Default: `"cloud"`
+  - Description: Select the Bitbucket API to target. Use `"server"` for Bitbucket Data Center/Server deployments.
+
+Example configuration:
+
+```toml
+[secrets_store.provider_tokens.bitbucket]
+token = "username:app_password"
+host = "bitbucket.example.com"
+user_id = "username"
+bitbucket_mode = "server"
+```
+
 ---
 
 > **Note**: Adjust configurations carefully, especially for memory, security, and network-related settings to ensure optimal performance and security.

--- a/frontend/__tests__/routes/git-settings.test.tsx
+++ b/frontend/__tests__/routes/git-settings.test.tsx
@@ -293,7 +293,7 @@ describe("Form submission", () => {
     expect(saveProvidersSpy).toHaveBeenCalledWith({
       github: { token: "test-token", host: "" },
       gitlab: { token: "", host: "" },
-      bitbucket: { token: "", host: "", bit_bucket_mode: "cloud" },
+      bitbucket: { token: "", host: "", bitbucket_mode: "cloud" },
       enterprise_sso: { token: "", host: "" },
     });
   });
@@ -318,7 +318,7 @@ describe("Form submission", () => {
     expect(saveProvidersSpy).toHaveBeenCalledWith({
       github: { token: "", host: "" },
       gitlab: { token: "test-token", host: "" },
-      bitbucket: { token: "", host: "", bit_bucket_mode: "cloud" },
+      bitbucket: { token: "", host: "", bitbucket_mode: "cloud" },
       enterprise_sso: { token: "", host: "" },
     });
   });
@@ -343,7 +343,7 @@ describe("Form submission", () => {
     expect(saveProvidersSpy).toHaveBeenCalledWith({
       github: { token: "", host: "" },
       gitlab: { token: "", host: "" },
-      bitbucket: { token: "test-token", host: "", bit_bucket_mode: "cloud" },
+      bitbucket: { token: "test-token", host: "", bitbucket_mode: "cloud" },
       enterprise_sso: { token: "", host: "" },
     });
   });
@@ -375,7 +375,7 @@ describe("Form submission", () => {
       bitbucket: {
         token: "",
         host: "bitbucket.example.com",
-        bit_bucket_mode: "server",
+        bitbucket_mode: "server",
       },
       enterprise_sso: { token: "", host: "" },
     });

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -311,7 +311,7 @@ export const handlers = [
     if (typeof body === "object" && body?.provider_tokens) {
       const rawTokens = body.provider_tokens as Record<
         string,
-        { token?: string; host?: string | null; bit_bucket_mode?: string }
+        { token?: string; host?: string | null; bitbucket_mode?: string }
       >;
 
       const providerTokensSet: Partial<
@@ -323,8 +323,8 @@ export const handlers = [
               return [provider as Provider, null];
             }
 
-            const normalizedMode = val.bit_bucket_mode as
-              | ProviderTokenSettings["bit_bucket_mode"]
+            const normalizedMode = val.bitbucket_mode as
+              | ProviderTokenSettings["bitbucket_mode"]
               | undefined;
 
             const shouldPersist =
@@ -340,7 +340,7 @@ export const handlers = [
               provider as Provider,
               {
                 host: val.host ?? null,
-                bit_bucket_mode: normalizedMode,
+                bitbucket_mode: normalizedMode,
               },
             ];
           })

--- a/frontend/src/routes/git-settings.tsx
+++ b/frontend/src/routes/git-settings.tsx
@@ -62,7 +62,7 @@ function GitSettingsScreen() {
       | undefined) ?? null;
   const existingBitbucketHost = existingBitbucketSettings?.host ?? null;
   const existingBitbucketMode: BitbucketMode =
-    existingBitbucketSettings?.bit_bucket_mode ?? "cloud";
+    existingBitbucketSettings?.bitbucket_mode ?? "cloud";
 
   const [bitbucketMode, setBitbucketMode] = React.useState<BitbucketMode>(
     existingBitbucketMode,
@@ -108,7 +108,7 @@ function GitSettingsScreen() {
       bitbucket: {
         token: bitbucketToken,
         host: bitbucketHost,
-        bit_bucket_mode: bitbucketModeValue,
+        bitbucket_mode: bitbucketModeValue,
       },
       enterprise_sso: { token: "", host: "" },
     };

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -12,12 +12,12 @@ export type BitbucketMode = "cloud" | "server";
 export type ProviderToken = {
   token: string;
   host: string | null;
-  bit_bucket_mode?: BitbucketMode;
+  bitbucket_mode?: BitbucketMode;
 };
 
 export type ProviderTokenSettings = {
   host: string | null;
-  bit_bucket_mode?: BitbucketMode;
+  bitbucket_mode?: BitbucketMode;
 };
 
 export type MCPSSEServer = {

--- a/openhands/integrations/bitbucket/bitbucket_service.py
+++ b/openhands/integrations/bitbucket/bitbucket_service.py
@@ -45,28 +45,27 @@ class BitBucketService(
         token: SecretStr | None = None,
         external_token_manager: bool = False,
         base_domain: str | None = None,
-        bit_bucket_mode: Literal['cloud', 'server'] = 'cloud',
+        bitbucket_mode: Literal['cloud', 'server'] = 'cloud',
     ) -> None:
         self.user_id = user_id
         self.external_token_manager = external_token_manager
         self.external_auth_id = external_auth_id
         self.external_auth_token = external_auth_token
         self.base_domain = base_domain or 'bitbucket.org'
-        self.bit_bucket_mode = bit_bucket_mode
-        self.username: str | None = None
+        self.bitbucket_mode = bitbucket_mode
 
-        if self.bit_bucket_mode not in {'cloud', 'server'}:
+        if self.bitbucket_mode not in {'cloud', 'server'}:
             raise ValueError(
-                f'Unsupported Bitbucket mode: {self.bit_bucket_mode}'
+                f'Unsupported Bitbucket mode: {self.bitbucket_mode}'
             )
 
         if token:
             self.token = token
             token_value = token.get_secret_value()
             if ':' in token_value:
-                self.username = token_value.split(':', 1)[0]
+                self.user_id = self.user_id or token_value.split(':', 1)[0]
 
-        if self.bit_bucket_mode == 'server':
+        if self.bitbucket_mode == 'server':
             self.BASE_URL = f'https://{self.base_domain}/rest/api/1.0'
         else:
             self.BASE_URL = f'https://api.{self.base_domain}/2.0'

--- a/openhands/integrations/bitbucket/service/base.py
+++ b/openhands/integrations/bitbucket/service/base.py
@@ -26,7 +26,7 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
 
     @property
     def _is_server(self) -> bool:
-        return getattr(self, 'bit_bucket_mode', 'cloud') == 'server'
+        return getattr(self, 'bitbucket_mode', 'cloud') == 'server'
 
     def _repo_api_base(self, owner: str, repo: str) -> str:
         if self._is_server:
@@ -158,10 +158,10 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
     async def get_user(self) -> User:
         """Get the authenticated user's information."""
         if self._is_server:
-            username = getattr(self, 'username', None)
-            if not username:
-                raise AuthenticationError('Username is required for Bitbucket Server access')
-            url = f'{self.BASE_URL}/users/{username}'
+            user_id = getattr(self, 'user_id', None)
+            if not user_id:
+                raise AuthenticationError('User ID is required for Bitbucket Server access')
+            url = f'{self.BASE_URL}/users/{user_id}'
             data, _ = await self._make_request(url)
             links = data.get('links', {})
             avatar = ''
@@ -172,8 +172,8 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
             display_name = data.get('displayName')
             email = data.get('emailAddress')
             return User(
-                id=str(data.get('id') or data.get('slug') or username),
-                login=data.get('name') or username,
+                id=str(data.get('id') or data.get('slug') or user_id),
+                login=data.get('name') or user_id,
                 avatar_url=avatar,
                 name=display_name,
                 email=email,

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -44,7 +44,7 @@ class ProviderToken(BaseModel):
     token: SecretStr | None = Field(default=None)
     user_id: str | None = Field(default=None)
     host: str | None = Field(default=None)
-    bit_bucket_mode: BitbucketMode | None = Field(default='cloud')
+    bitbucket_mode: BitbucketMode | None = Field(default='cloud')
 
     model_config = ConfigDict(
         frozen=True,  # Makes the entire model immutable
@@ -64,17 +64,17 @@ class ProviderToken(BaseModel):
                 token_str = ''  # type: ignore[unreachable]
             user_id = token_value.get('user_id')
             host = token_value.get('host')
-            bit_bucket_mode = token_value.get('bit_bucket_mode')
-            if bit_bucket_mode not in (None, 'cloud', 'server'):
-                raise ValueError('Invalid bit_bucket_mode value')
+            bitbucket_mode = token_value.get('bitbucket_mode')
+            if bitbucket_mode not in (None, 'cloud', 'server'):
+                raise ValueError('Invalid bitbucket_mode value')
             resolved_mode: BitbucketMode = 'cloud'
-            if bit_bucket_mode is not None:
-                resolved_mode = cast(BitbucketMode, bit_bucket_mode)
+            if bitbucket_mode is not None:
+                resolved_mode = cast(BitbucketMode, bitbucket_mode)
             return cls(
                 token=SecretStr(token_str),
                 user_id=user_id,
                 host=host,
-                bit_bucket_mode=resolved_mode,
+                bitbucket_mode=resolved_mode,
             )
 
         else:
@@ -175,9 +175,9 @@ class ProviderHandler:
 
         if provider == ProviderType.BITBUCKET:
             bitbucket_mode: BitbucketMode = (
-                token.bit_bucket_mode if token.bit_bucket_mode is not None else 'cloud'
+                token.bitbucket_mode if token.bitbucket_mode is not None else 'cloud'
             )
-            kwargs['bit_bucket_mode'] = bitbucket_mode
+            kwargs['bitbucket_mode'] = bitbucket_mode
 
         return service_class(**kwargs)
 

--- a/openhands/integrations/utils.py
+++ b/openhands/integrations/utils.py
@@ -12,7 +12,7 @@ from openhands.integrations.provider import ProviderType
 async def validate_provider_token(
     token: SecretStr,
     base_domain: str | None = None,
-    bit_bucket_mode: Literal['cloud', 'server'] | None = None,
+    bitbucket_mode: Literal['cloud', 'server'] | None = None,
 ) -> ProviderType | None:
     """Determine whether a token is for GitHub, GitLab, or Bitbucket by attempting to get user info
     from the services.
@@ -52,8 +52,8 @@ async def validate_provider_token(
     # Try Bitbucket last
     bitbucket_error = None
     try:
-        if bit_bucket_mode is not None:
-            resolved_mode = bit_bucket_mode
+        if bitbucket_mode is not None:
+            resolved_mode = bitbucket_mode
         elif base_domain and base_domain != 'bitbucket.org':
             resolved_mode = 'server'
         else:
@@ -62,7 +62,7 @@ async def validate_provider_token(
         bitbucket_service = BitBucketService(
             token=token,
             base_domain=base_domain,
-            bit_bucket_mode=resolved_mode,
+            bitbucket_mode=resolved_mode,
         )
         await bitbucket_service.get_user()
         return ProviderType.BITBUCKET

--- a/openhands/resolver/issue_handler_factory.py
+++ b/openhands/resolver/issue_handler_factory.py
@@ -25,7 +25,7 @@ class IssueHandlerFactory:
         base_domain: str,
         issue_type: str,
         llm_config: LLMConfig,
-        bit_bucket_mode: Literal['cloud', 'server'] = 'cloud',
+        bitbucket_mode: Literal['cloud', 'server'] = 'cloud',
     ) -> None:
         self.owner = owner
         self.repo = repo
@@ -35,7 +35,7 @@ class IssueHandlerFactory:
         self.base_domain = base_domain
         self.issue_type = issue_type
         self.llm_config = llm_config
-        self.bit_bucket_mode = bit_bucket_mode
+        self.bitbucket_mode = bitbucket_mode
 
     def create(self) -> ServiceContextIssue | ServiceContextPR:
         if self.issue_type == 'issue':
@@ -67,9 +67,9 @@ class IssueHandlerFactory:
                         self.owner,
                         self.repo,
                         self.token,
-                        self.username,
-                        self.base_domain,
-                        bit_bucket_mode=self.bit_bucket_mode,
+                        user_id=self.username,
+                        base_domain=self.base_domain,
+                        bitbucket_mode=self.bitbucket_mode,
                     ),
                     self.llm_config,
                 )
@@ -104,9 +104,9 @@ class IssueHandlerFactory:
                         self.owner,
                         self.repo,
                         self.token,
-                        self.username,
-                        self.base_domain,
-                        bit_bucket_mode=self.bit_bucket_mode,
+                        user_id=self.username,
+                        base_domain=self.base_domain,
+                        bitbucket_mode=self.bitbucket_mode,
                     ),
                     self.llm_config,
                 )

--- a/openhands/resolver/issue_resolver.py
+++ b/openhands/resolver/issue_resolver.py
@@ -132,11 +132,11 @@ class IssueResolver:
                 else 'bitbucket.org'
             )
 
-        self.bit_bucket_mode: Literal['cloud', 'server'] = getattr(
-            args, 'bit_bucket_mode', 'cloud'
+        self.bitbucket_mode: Literal['cloud', 'server'] = getattr(
+            args, 'bitbucket_mode', 'cloud'
         )
-        if self.bit_bucket_mode not in {'cloud', 'server'}:
-            raise ValueError(f'Unsupported Bitbucket mode: {self.bit_bucket_mode}')
+        if self.bitbucket_mode not in {'cloud', 'server'}:
+            raise ValueError(f'Unsupported Bitbucket mode: {self.bitbucket_mode}')
 
         self.output_dir = args.output_dir
         self.issue_type = issue_type
@@ -177,7 +177,7 @@ class IssueResolver:
             base_domain=base_domain,
             issue_type=self.issue_type,
             llm_config=self.app_config.get_llm_config(),
-            bit_bucket_mode=self.bit_bucket_mode,
+            bitbucket_mode=self.bitbucket_mode,
         )
         self.issue_handler = factory.create()
 

--- a/openhands/resolver/send_pull_request.py
+++ b/openhands/resolver/send_pull_request.py
@@ -246,14 +246,14 @@ def send_pull_request(
     base_domain: str | None = None,
     git_user_name: str = 'openhands',
     git_user_email: str = 'openhands@all-hands.dev',
-    bit_bucket_mode: Literal['cloud', 'server'] = 'cloud',
+    bitbucket_mode: Literal['cloud', 'server'] = 'cloud',
 ) -> str:
     """Send a pull request to a GitHub, GitLab, or Bitbucket repository.
 
     Args:
         issue: The issue to send the pull request for
         token: The token to use for authentication
-        username: The username, if provided
+        username: The username, if provided. For Bitbucket this is treated as the user ID.
         platform: The platform of the repository.
         patch_dir: The directory containing the patches to apply
         pr_type: The type: branch (no PR created), draft or ready (regular PR created)
@@ -263,7 +263,7 @@ def send_pull_request(
         reviewer: The username of the reviewer to assign
         pr_title: Custom title for the pull request (optional)
         base_domain: The base domain for the git server (defaults to "github.com" for GitHub, "gitlab.com" for GitLab, and "bitbucket.org" for Bitbucket)
-        bit_bucket_mode: Bitbucket API mode to use ("cloud" or "server").
+        bitbucket_mode: Bitbucket API mode to use ("cloud" or "server").
     """
     if pr_type not in ['branch', 'draft', 'ready']:
         raise ValueError(f'Invalid pr_type: {pr_type}')
@@ -295,9 +295,9 @@ def send_pull_request(
                 issue.owner,
                 issue.repo,
                 token,
-                username,
-                base_domain,
-                bit_bucket_mode=bit_bucket_mode,
+                user_id=username,
+                base_domain=base_domain,
+                bitbucket_mode=bitbucket_mode,
             ),
             None,
         )
@@ -523,7 +523,7 @@ def process_single_issue(
     base_domain: str | None = None,
     git_user_name: str = 'openhands',
     git_user_email: str = 'openhands@all-hands.dev',
-    bit_bucket_mode: Literal['cloud', 'server'] = 'cloud',
+    bitbucket_mode: Literal['cloud', 'server'] = 'cloud',
 ) -> None:
     # Determine default base_domain based on platform
     if base_domain is None:
@@ -590,7 +590,7 @@ def process_single_issue(
             base_domain=base_domain,
             git_user_name=git_user_name,
             git_user_email=git_user_email,
-            bit_bucket_mode=bit_bucket_mode,
+            bitbucket_mode=bitbucket_mode,
         )
 
 
@@ -689,7 +689,9 @@ def main() -> None:
         help='Base domain for the git server (defaults to "github.com" for GitHub and "gitlab.com" for GitLab)',
     )
     parser.add_argument(
+        '--bitbucket-mode',
         '--bit-bucket-mode',
+        dest='bitbucket_mode',
         type=str,
         default='cloud',
         choices=['cloud', 'server'],
@@ -756,7 +758,7 @@ def main() -> None:
         my_args.base_domain,
         my_args.git_user_name,
         my_args.git_user_email,
-        my_args.bit_bucket_mode,
+        my_args.bitbucket_mode,
     )
 
 

--- a/openhands/server/routes/secrets.py
+++ b/openhands/server/routes/secrets.py
@@ -77,7 +77,7 @@ async def check_provider_tokens(
                 confirmed_token_type = await validate_provider_token(
                     token_value.token,
                     token_value.host,
-                    token_value.bit_bucket_mode,
+                    token_value.bitbucket_mode,
                 )  # FE always sends latest host
                 msg = process_token_validation_result(confirmed_token_type, token_type)
 
@@ -94,7 +94,7 @@ async def check_provider_tokens(
                 confirmed_token_type = await validate_provider_token(
                     existing_token.token,
                     token_value.host,
-                    token_value.bit_bucket_mode or existing_token.bit_bucket_mode,
+                    token_value.bitbucket_mode or existing_token.bitbucket_mode,
                 )  # Host has changed, check it against existing token
                 if not confirmed_token_type or confirmed_token_type != token_type:
                     msg = process_token_validation_result(
@@ -138,8 +138,8 @@ async def store_provider_tokens(
 
                 update_fields = {'host': token_value.host}
                 if provider == ProviderType.BITBUCKET:
-                    update_fields['bit_bucket_mode'] = (
-                        token_value.bit_bucket_mode or 'cloud'
+                    update_fields['bitbucket_mode'] = (
+                        token_value.bitbucket_mode or 'cloud'
                     )
 
                 provider_info.provider_tokens[provider] = provider_info.provider_tokens[

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -60,11 +60,11 @@ async def load_settings(
                 if provider_token.token or provider_token.user_id:
                     bitbucket_mode = None
                     if provider_type == ProviderType.BITBUCKET:
-                        bitbucket_mode = provider_token.bit_bucket_mode or 'cloud'
+                        bitbucket_mode = provider_token.bitbucket_mode or 'cloud'
 
                     provider_tokens_set[provider_type] = ProviderTokenSettings(
                         host=provider_token.host,
-                        bit_bucket_mode=bitbucket_mode,
+                        bitbucket_mode=bitbucket_mode,
                     )
 
         settings_with_token_data = GETSettingsModel(

--- a/openhands/server/settings.py
+++ b/openhands/server/settings.py
@@ -29,7 +29,7 @@ class POSTCustomSecrets(BaseModel):
 
 class ProviderTokenSettings(BaseModel):
     host: str | None = None
-    bit_bucket_mode: Literal['cloud', 'server'] | None = None
+    bitbucket_mode: Literal['cloud', 'server'] | None = None
 
 
 class GETSettingsModel(Settings):

--- a/openhands/storage/data_models/user_secrets.py
+++ b/openhands/storage/data_models/user_secrets.py
@@ -68,9 +68,9 @@ class UserSecrets(BaseModel):
                 'host': provider_token.host,
                 'user_id': provider_token.user_id,
             }
-            if provider_token.bit_bucket_mode:
-                tokens[token_type_str]['bit_bucket_mode'] = (
-                    provider_token.bit_bucket_mode
+            if provider_token.bitbucket_mode:
+                tokens[token_type_str]['bitbucket_mode'] = (
+                    provider_token.bitbucket_mode
                 )
 
         return tokens

--- a/tests/unit/integrations/bitbucket/test_bitbucket.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket.py
@@ -29,7 +29,7 @@ def bitbucket_handler():
         owner='test-workspace',
         repo='test-repo',
         token='test-token',
-        username='test-user',
+        user_id='test-user',
     )
 
 
@@ -38,13 +38,13 @@ def test_init():
         owner='test-workspace',
         repo='test-repo',
         token='test-token',
-        username='test-user',
+        user_id='test-user',
     )
 
     assert handler.owner == 'test-workspace'
     assert handler.repo == 'test-repo'
     assert handler.token == 'test-token'
-    assert handler.username == 'test-user'
+    assert handler.user_id == 'test-user'
     assert handler.base_domain == 'bitbucket.org'
     assert handler.base_url == 'https://api.bitbucket.org/2.0'
     assert (
@@ -63,9 +63,9 @@ def test_init_server_mode():
         owner='PROJ',
         repo='test-repo',
         token='user:pass',
-        username=None,
+        user_id=None,
         base_domain='bitbucket.example.com',
-        bit_bucket_mode='server',
+        bitbucket_mode='server',
     )
 
     assert handler.base_url == 'https://bitbucket.example.com/rest/api/1.0'
@@ -176,9 +176,9 @@ def test_create_pr_server_mode(mock_post):
         owner='PROJ',
         repo='test-repo',
         token='user:pass',
-        username=None,
+        user_id=None,
         base_domain='bitbucket.example.com',
-        bit_bucket_mode='server',
+        bitbucket_mode='server',
     )
 
     mock_response = MagicMock()
@@ -285,9 +285,9 @@ def test_send_pull_request_bitbucket(
         'test-workspace',
         'test-repo',
         'test-token',
-        None,
-        'bitbucket.org',
-        bit_bucket_mode='cloud',
+        user_id=None,
+        base_domain='bitbucket.org',
+        bitbucket_mode='cloud',
     )
 
     # Verify ServiceContextIssue was created correctly
@@ -493,7 +493,7 @@ async def test_validate_provider_token_with_bitbucket_server_mode():
         mock_bitbucket_service.assert_called_once_with(
             token=token,
             base_domain=base_domain,
-            bit_bucket_mode='server',
+            bitbucket_mode='server',
         )
         assert result == ProviderType.BITBUCKET
 
@@ -827,7 +827,7 @@ async def test_fetch_paginated_data_server_mode():
     service = BitBucketService(
         token=SecretStr('user:pass'),
         base_domain='bitbucket.example.com',
-        bit_bucket_mode='server',
+        bitbucket_mode='server',
     )
 
     first_page = ({'values': [{'id': 1}], 'isLastPage': False, 'nextPageStart': 2}, {})
@@ -878,7 +878,7 @@ def test_parse_repository_server_mode():
     service = BitBucketService(
         token=SecretStr('user:pass'),
         base_domain='bitbucket.example.com',
-        bit_bucket_mode='server',
+        bitbucket_mode='server',
     )
 
     repo_data = {


### PR DESCRIPTION
## Summary
- rename all Bitbucket configuration fields from `bit_bucket_mode` to `bitbucket_mode`
- update Bitbucket integrations to rely on `user_id` instead of `username`
- document Bitbucket provider token options for `config.toml`

## Testing
- `pytest tests/unit/integrations/bitbucket/test_bitbucket.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce764f687c832caefe9da0373f51a6