### PR TITLE
Adjust HTTP client verification defaults

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -49,6 +49,9 @@
 # Enable the browser environment
 #enable_browser = true
 
+# Skip TLS certificate verification for outbound HTTP requests (NOT recommended)
+#insecure_skip_verify = false
+
 # Maximum budget per task, 0.0 means no limit
 #max_budget_per_task = 0.0
 

--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -37,6 +37,8 @@ class OpenHandsConfig(BaseModel):
         file_store_web_hook_url: Optional url for file store web hook
         file_store_web_hook_headers: Optional headers for file_store web hook
         enable_browser: Whether to enable the browser environment
+        insecure_skip_verify: When True, TLS certificate verification is disabled for outbound HTTP requests.
+            Defaults to None, meaning the system default (verify certificates).
         save_trajectory_path: Either a folder path to store trajectories with auto-generated filenames, or a designated trajectory file path.
         save_screenshots_in_trajectory: Whether to save screenshots in trajectory (in encoded image format).
         replay_trajectory_path: Path to load trajectory and replay. If provided, trajectory would be replayed first before user's instruction.
@@ -74,6 +76,10 @@ class OpenHandsConfig(BaseModel):
     file_store_web_hook_url: str | None = Field(default=None)
     file_store_web_hook_headers: dict | None = Field(default=None)
     file_store_web_hook_batch: bool = Field(default=False)
+    insecure_skip_verify: bool | None = Field(
+        default=None,
+        description='Disable TLS certificate verification when set to true. Defaults to verifying certificates.',
+    )
     enable_browser: bool = Field(default=True)
     save_trajectory_path: str | None = Field(default=None)
     save_screenshots_in_trajectory: bool = Field(default=False)

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -33,6 +33,7 @@ from openhands.core.config.security_config import SecurityConfig
 from openhands.storage import get_file_store
 from openhands.storage.files import FileStore
 from openhands.utils.import_utils import get_impl
+from openhands.utils.http_session import configure_http_session
 
 JWT_SECRET = '.jwt_secret'
 CONFIG_FILE_ENV_VAR = 'CONFIG_FILE'
@@ -457,6 +458,11 @@ def finalize_config(cfg: OpenHandsConfig) -> None:
                 get_file_store(cfg.file_store, cfg.file_store_path)
             )
         )
+
+    if cfg.insecure_skip_verify is None:
+        configure_http_session()
+    else:
+        configure_http_session(verify=not cfg.insecure_skip_verify)
 
     # If CLIRuntime is selected, disable Jupyter for all agents
     # Assuming 'cli' is the identifier for CLIRuntime

--- a/openhands/utils/http_session.py
+++ b/openhands/utils/http_session.py
@@ -1,11 +1,63 @@
+import os
+import ssl
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import MutableMapping
 
 import httpx
 
 from openhands.core.logger import openhands_logger as logger
 
-CLIENT = httpx.Client()
+
+def _env_insecure_skip_verify() -> bool:
+    truthy = {'1', 'true', 'yes', 'on'}
+    for env_var in ('OPENHANDS_INSECURE_SKIP_VERIFY', 'INSECURE_SKIP_VERIFY'):
+        value = os.environ.get(env_var)
+        if value is not None:
+            return value.strip().lower() in truthy
+    return False
+
+
+_client_lock = Lock()
+_verify_certificates: bool = not _env_insecure_skip_verify()
+_client: httpx.Client | None = None
+
+
+def _build_client(verify: bool) -> httpx.Client:
+    if verify:
+        return httpx.Client(verify=ssl.create_default_context())
+    return httpx.Client(verify=False)
+
+
+def _get_client() -> httpx.Client:
+    global _client
+    if _client is None:
+        with _client_lock:
+            if _client is None:
+                _client = _build_client(_verify_certificates)
+    return _client
+
+
+def configure_http_session(*, verify: bool | None = None) -> None:
+    """Configure the shared HTTPX client used by HttpSession."""
+
+    global _client, _verify_certificates
+
+    target_verify = _verify_certificates
+    if verify is not None:
+        target_verify = verify
+    elif _client is None:
+        # Ensure we honour environment variables on first configuration
+        target_verify = not _env_insecure_skip_verify()
+
+    if target_verify == _verify_certificates and _client is not None:
+        return
+
+    with _client_lock:
+        if _client is not None:
+            _client.close()
+        _verify_certificates = target_verify
+        _client = _build_client(_verify_certificates)
 
 
 @dataclass
@@ -27,7 +79,7 @@ class HttpSession:
         headers = kwargs.get('headers') or {}
         headers = {**self.headers, **headers}
         kwargs['headers'] = headers
-        return CLIENT.request(*args, **kwargs)
+        return _get_client().request(*args, **kwargs)
 
     def stream(self, *args, **kwargs):
         if self._is_closed:
@@ -38,7 +90,7 @@ class HttpSession:
         headers = kwargs.get('headers') or {}
         headers = {**self.headers, **headers}
         kwargs['headers'] = headers
-        return CLIENT.stream(*args, **kwargs)
+        return _get_client().stream(*args, **kwargs)
 
     def get(self, *args, **kwargs):
         return self.request('GET', *args, **kwargs)


### PR DESCRIPTION
## Summary
- add a new `insecure_skip_verify` setting to the core config template and model so TLS checks can be optionally disabled
- wire the finalized config into the shared HTTP client to honour the new toggle while still defaulting to host CA bundles
- update the reusable HTTP session helper to support dynamic verify configuration and reuse across requests
- ensure the shared httpx client relies on the system trust store when verification remains enabled and simplify the environment flag parsing

## Testing
- pytest tests/unit/core/config/test_config.py