### PR TITLE
Ensure httpx clients use default SSL context

### DIFF
--- a/enterprise/integrations/jira/jira_manager.py
+++ b/enterprise/integrations/jira/jira_manager.py
@@ -32,6 +32,7 @@ from openhands.integrations.service_types import Repository
 from openhands.server.shared import server_config
 from openhands.server.types import LLMAuthenticationError, MissingSettingsError
 from openhands.server.user_auth.user_auth import UserAuth
+from openhands.utils.http_session import httpx_verify_option
 
 JIRA_CLOUD_API_URL = 'https://api.atlassian.com/ex/jira'
 
@@ -408,7 +409,7 @@ class JiraManager(Manager):
         svc_acc_api_key: str,
     ) -> Tuple[str, str]:
         url = f'{JIRA_CLOUD_API_URL}/{jira_cloud_id}/rest/api/2/issue/{job_context.issue_key}'
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.get(url, auth=(svc_acc_email, svc_acc_api_key))
             response.raise_for_status()
             issue_payload = response.json()
@@ -443,7 +444,7 @@ class JiraManager(Manager):
             f'{JIRA_CLOUD_API_URL}/{jira_cloud_id}/rest/api/2/issue/{issue_key}/comment'
         )
         data = {'body': message.message}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(
                 url, auth=(svc_acc_email, svc_acc_api_key), json=data
             )

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -34,6 +34,7 @@ from openhands.integrations.service_types import Repository
 from openhands.server.shared import server_config
 from openhands.server.types import LLMAuthenticationError, MissingSettingsError
 from openhands.server.user_auth.user_auth import UserAuth
+from openhands.utils.http_session import httpx_verify_option
 
 
 class JiraDcManager(Manager):
@@ -422,7 +423,7 @@ class JiraDcManager(Manager):
         """Get issue details from Jira DC API."""
         url = f'{job_context.base_api_url}/rest/api/2/issue/{job_context.issue_key}'
         headers = {'Authorization': f'Bearer {svc_acc_api_key}'}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.get(url, headers=headers)
             response.raise_for_status()
             issue_payload = response.json()
@@ -452,7 +453,7 @@ class JiraDcManager(Manager):
         url = f'{base_api_url}/rest/api/2/issue/{issue_key}/comment'
         headers = {'Authorization': f'Bearer {svc_acc_api_key}'}
         data = {'body': message.message}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, headers=headers, json=data)
             response.raise_for_status()
             return response.json()

--- a/enterprise/integrations/linear/linear_manager.py
+++ b/enterprise/integrations/linear/linear_manager.py
@@ -31,6 +31,7 @@ from openhands.integrations.service_types import Repository
 from openhands.server.shared import server_config
 from openhands.server.types import LLMAuthenticationError, MissingSettingsError
 from openhands.server.user_auth.user_auth import UserAuth
+from openhands.utils.http_session import httpx_verify_option
 
 
 class LinearManager(Manager):
@@ -408,7 +409,7 @@ class LinearManager(Manager):
     async def _query_api(self, query: str, variables: Dict, api_key: str) -> Dict:
         """Query Linear GraphQL API."""
         headers = {'Authorization': api_key}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(
                 self.api_url,
                 headers=headers,

--- a/enterprise/server/auth/token_manager.py
+++ b/enterprise/server/auth/token_manager.py
@@ -37,6 +37,7 @@ from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_
 
 from openhands.core.config import load_openhands_config
 from openhands.integrations.service_types import ProviderType
+from openhands.utils.http_session import httpx_verify_option
 
 # Create a function to get config to avoid circular imports
 _config = None
@@ -201,7 +202,7 @@ class TokenManager:
         access_token: str,
         idp: ProviderType,
     ) -> dict[str, str | int]:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             base_url = KEYCLOAK_SERVER_URL_EXT if self.external else KEYCLOAK_SERVER_URL
             url = f'{base_url}/realms/{KEYCLOAK_REALM_NAME}/broker/{idp.value}/token'
             headers = {
@@ -359,7 +360,7 @@ class TokenManager:
             'refresh_token': refresh_token,
             'grant_type': 'refresh_token',
         }
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, data=payload)
             response.raise_for_status()
             logger.info('Successfully refreshed GitHub token')
@@ -385,7 +386,7 @@ class TokenManager:
             'refresh_token': refresh_token,
             'grant_type': 'refresh_token',
         }
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, data=payload)
             response.raise_for_status()
             logger.info('Successfully refreshed GitLab token')
@@ -413,7 +414,7 @@ class TokenManager:
             'refresh_token': refresh_token,
         }
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, data=data, headers=headers)
             response.raise_for_status()
             logger.info('Successfully refreshed Bitbucket token')

--- a/enterprise/server/routes/api_keys.py
+++ b/enterprise/server/routes/api_keys.py
@@ -11,6 +11,7 @@ from storage.user_settings import UserSettings
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.user_auth import get_user_id
 from openhands.utils.async_utils import call_sync_from_async
+from openhands.utils.http_session import httpx_verify_option
 
 
 # Helper functions for BYOR API key management
@@ -67,6 +68,7 @@ async def generate_byor_key(user_id: str) -> str | None:
 
     try:
         async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
             headers={
                 'x-goog-api-key': LITE_LLM_API_KEY,
             }
@@ -119,6 +121,7 @@ async def delete_byor_key_from_litellm(user_id: str, byor_key: str) -> bool:
 
     try:
         async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
             headers={
                 'x-goog-api-key': LITE_LLM_API_KEY,
             }

--- a/enterprise/server/routes/billing.py
+++ b/enterprise/server/routes/billing.py
@@ -26,6 +26,7 @@ from storage.subscription_access import SubscriptionAccess
 from storage.user_settings import UserSettings
 
 from openhands.server.user_auth import get_user_id
+from openhands.utils.http_session import httpx_verify_option
 
 stripe.api_key = STRIPE_API_KEY
 billing_router = APIRouter(prefix='/api/billing')
@@ -78,7 +79,7 @@ def calculate_credits(user_info: LiteLlmUserInfo) -> float:
 async def get_credits(user_id: str = Depends(get_user_id)) -> GetCreditsResponse:
     if not stripe_service.STRIPE_API_KEY:
         return GetCreditsResponse()
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
         user_json = await _get_litellm_user(client, user_id)
         credits = calculate_credits(user_json['user_info'])
     return GetCreditsResponse(credits=Decimal('{:.2f}'.format(credits)))
@@ -390,7 +391,7 @@ async def success_callback(session_id: str, request: Request):
             )
             raise HTTPException(status.HTTP_400_BAD_REQUEST)
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             # Update max budget in litellm
             user_json = await _get_litellm_user(client, billing_session.user_id)
             amount_subtotal = stripe_session.amount_subtotal or 0

--- a/enterprise/server/routes/github_proxy.py
+++ b/enterprise/server/routes/github_proxy.py
@@ -11,6 +11,7 @@ from fastapi.responses import RedirectResponse
 from server.logger import logger
 
 from openhands.server.shared import config
+from openhands.utils.http_session import httpx_verify_option
 
 GITHUB_PROXY_ENDPOINTS = bool(os.environ.get('GITHUB_PROXY_ENDPOINTS'))
 
@@ -87,7 +88,7 @@ def add_github_proxy_routes(app: FastAPI):
             ]
             body = urlencode(query_params, doseq=True)
         url = 'https://github.com/login/oauth/access_token'
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, content=body)
             return Response(
                 response.content,
@@ -101,7 +102,7 @@ def add_github_proxy_routes(app: FastAPI):
         logger.info(f'github_proxy_post:1:{path}')
         body = await request.body()
         url = f'https://github.com/{path}'
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, content=body, headers=request.headers)
             return Response(
                 response.content,

--- a/enterprise/server/saas_nested_conversation_manager.py
+++ b/enterprise/server/saas_nested_conversation_manager.py
@@ -55,6 +55,7 @@ from openhands.utils.async_utils import call_sync_from_async
 from openhands.utils.import_utils import get_impl
 from openhands.utils.shutdown_listener import should_continue
 from openhands.utils.utils import create_registry_and_conversation_stats
+from openhands.utils.http_session import httpx_verify_option
 
 # Pattern for accessing runtime pods externally
 RUNTIME_URL_PATTERN = os.getenv(
@@ -261,6 +262,7 @@ class SaasNestedConversationManager(ConversationManager):
     ):
         logger.info('starting_nested_conversation', extra={'sid': sid})
         async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
             headers={
                 'X-Session-API-Key': session_api_key,
             }
@@ -449,6 +451,7 @@ class SaasNestedConversationManager(ConversationManager):
             raise ValueError(f'no_such_conversation:{sid}')
         nested_url = self._get_nested_url_for_runtime(runtime['runtime_id'], sid)
         async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
             headers={
                 'X-Session-API-Key': runtime['session_api_key'],
             }
@@ -516,6 +519,7 @@ class SaasNestedConversationManager(ConversationManager):
                 return None
 
             async with httpx.AsyncClient(
+                verify=httpx_verify_option(),
                 headers={
                     'X-Session-API-Key': session_api_key,
                 }
@@ -792,6 +796,7 @@ class SaasNestedConversationManager(ConversationManager):
     @contextlib.asynccontextmanager
     async def _httpx_client(self):
         async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
             headers={'X-API-Key': self.config.sandbox.api_key or ''},
             timeout=_HTTP_TIMEOUT,
         ) as client:

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -32,6 +32,7 @@ from openhands.server.settings import Settings
 from openhands.storage import get_file_store
 from openhands.storage.settings.settings_store import SettingsStore
 from openhands.utils.async_utils import call_sync_from_async
+from openhands.utils.http_session import httpx_verify_option
 
 
 @dataclass
@@ -216,6 +217,7 @@ class SaasSettingsStore(SettingsStore):
             )
 
             async with httpx.AsyncClient(
+                verify=httpx_verify_option(),
                 headers={
                     'x-goog-api-key': LITE_LLM_API_KEY,
                 }

--- a/openhands/integrations/bitbucket/service/base.py
+++ b/openhands/integrations/bitbucket/service/base.py
@@ -16,6 +16,7 @@ from openhands.integrations.service_types import (
     ResourceNotFoundError,
     User,
 )
+from openhands.utils.http_session import httpx_verify_option
 
 
 class BitBucketMixinBase(BaseGitService, HTTPClient):
@@ -114,7 +115,7 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
 
         """
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 bitbucket_headers = await self._get_headers()
                 response = await self.execute_request(
                     client, url, bitbucket_headers, params, method

--- a/openhands/integrations/github/service/base.py
+++ b/openhands/integrations/github/service/base.py
@@ -12,6 +12,7 @@ from openhands.integrations.service_types import (
     UnknownException,
     User,
 )
+from openhands.utils.http_session import httpx_verify_option
 
 
 class GitHubMixinBase(BaseGitService, HTTPClient):
@@ -51,7 +52,7 @@ class GitHubMixinBase(BaseGitService, HTTPClient):
         method: RequestMethod = RequestMethod.GET,
     ) -> tuple[Any, dict]:  # type: ignore[override]
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 github_headers = await self._get_headers()
 
                 # Make initial request
@@ -96,7 +97,7 @@ class GitHubMixinBase(BaseGitService, HTTPClient):
         self, query: str, variables: dict[str, Any]
     ) -> dict[str, Any]:
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 github_headers = await self._get_headers()
 
                 variables_preview = self._sanitize_for_logging(variables)

--- a/openhands/integrations/gitlab/service/base.py
+++ b/openhands/integrations/gitlab/service/base.py
@@ -11,6 +11,7 @@ from openhands.integrations.service_types import (
     UnknownException,
     User,
 )
+from openhands.utils.http_session import httpx_verify_option
 
 
 class GitLabMixinBase(BaseGitService, HTTPClient):
@@ -49,7 +50,7 @@ class GitLabMixinBase(BaseGitService, HTTPClient):
         method: RequestMethod = RequestMethod.GET,
     ) -> tuple[Any, dict]:  # type: ignore[override]
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 gitlab_headers = await self._get_headers()
 
                 # Make initial request
@@ -112,7 +113,7 @@ class GitLabMixinBase(BaseGitService, HTTPClient):
         if variables is None:
             variables = {}
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 gitlab_headers = await self._get_headers()
                 # Add content type header for GraphQL
                 gitlab_headers['Content-Type'] = 'application/json'

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -36,6 +36,7 @@ from openhands.integrations.service_types import (
 )
 from openhands.microagent.types import MicroagentContentResponse, MicroagentResponse
 from openhands.server.types import AppMode
+from openhands.utils.http_session import httpx_verify_option
 
 BitbucketMode = Literal['cloud', 'server']
 
@@ -201,7 +202,7 @@ class ProviderHandler:
                 provider,
                 bool(self.sid),
             )
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 resp = await client.get(
                     self.REFRESH_TOKEN_URL,
                     headers={

--- a/openhands/resolver/interfaces/bitbucket.py
+++ b/openhands/resolver/interfaces/bitbucket.py
@@ -10,6 +10,7 @@ from openhands.resolver.interfaces.issue import (
     ReviewThread,
 )
 from openhands.resolver.utils import extract_issue_references
+from openhands.utils.http_session import httpx_verify_option
 
 
 class BitbucketIssueHandler(IssueHandlerInterface):
@@ -118,7 +119,7 @@ class BitbucketIssueHandler(IssueHandlerInterface):
         """
         if self.bitbucket_mode == 'server':
             url = f'{self._get_repo_api_base()}/pull-requests/{issue_number}'
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
                 response = await client.get(url, headers=self.headers)
                 response.raise_for_status()
                 data = response.json()
@@ -135,7 +136,7 @@ class BitbucketIssueHandler(IssueHandlerInterface):
             )
 
         url = f'{self._get_repo_api_base()}/issues/{issue_number}'
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.get(url, headers=self.headers)
             response.raise_for_status()
             data = response.json()

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -38,6 +38,7 @@ from openhands.runtime.impl.docker.docker_runtime import (
 )
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.plugins.vscode import VSCodeRequirement
+from openhands.utils.http_session import httpx_verify_option
 from openhands.runtime.runtime_status import RuntimeStatus
 from openhands.runtime.utils import find_available_tcp_port
 from openhands.runtime.utils.command import get_action_execution_server_startup_command
@@ -760,7 +761,7 @@ def _create_warm_server(
         )
 
         # Wait for the server to be ready
-        session = httpx.Client(timeout=30)
+        session = httpx.Client(timeout=30, verify=httpx_verify_option())
 
         # Use tenacity to retry the connection
         @tenacity.retry(

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -44,6 +44,7 @@ from openhands.storage.locations import get_conversation_dir
 from openhands.utils.async_utils import call_sync_from_async
 from openhands.utils.import_utils import get_impl
 from openhands.utils.utils import create_registry_and_conversation_stats
+from openhands.utils.http_session import httpx_verify_option
 
 
 @dataclass
@@ -199,6 +200,7 @@ class DockerNestedConversationManager(ConversationManager):
             await call_sync_from_async(runtime.wait_until_alive)
             await call_sync_from_async(runtime.setup_initial_env)
             async with httpx.AsyncClient(
+                verify=httpx_verify_option(),
                 headers={
                     'X-Session-API-Key': self._get_session_api_key_for_conversation(sid)
                 }
@@ -295,6 +297,7 @@ class DockerNestedConversationManager(ConversationManager):
 
     async def send_event_to_conversation(self, sid, data):
         async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
             headers={
                 'X-Session-API-Key': self._get_session_api_key_for_conversation(sid)
             }
@@ -318,6 +321,7 @@ class DockerNestedConversationManager(ConversationManager):
         try:
             nested_url = self.get_nested_url_for_container(container)
             async with httpx.AsyncClient(
+                verify=httpx_verify_option(),
                 headers={
                     'X-Session-API-Key': self._get_session_api_key_for_conversation(sid)
                 }
@@ -356,6 +360,7 @@ class DockerNestedConversationManager(ConversationManager):
         """
         try:
             async with httpx.AsyncClient(
+                verify=httpx_verify_option(),
                 headers={
                     'X-Session-API-Key': self._get_session_api_key_for_conversation(
                         conversation_id

--- a/openhands/storage/__init__.py
+++ b/openhands/storage/__init__.py
@@ -9,6 +9,7 @@ from openhands.storage.local import LocalFileStore
 from openhands.storage.memory import InMemoryFileStore
 from openhands.storage.s3 import S3FileStore
 from openhands.storage.web_hook import WebHookFileStore
+from openhands.utils.http_session import httpx_verify_option
 
 
 def get_file_store(
@@ -38,7 +39,10 @@ def get_file_store(
                     'SESSION_API_KEY'
                 )
 
-        client = httpx.Client(headers=file_store_web_hook_headers or {})
+        client = httpx.Client(
+            headers=file_store_web_hook_headers or {},
+            verify=httpx_verify_option(),
+        )
 
         if file_store_web_hook_batch:
             # Use batched webhook file store

--- a/openhands/storage/batched_web_hook.py
+++ b/openhands/storage/batched_web_hook.py
@@ -7,6 +7,7 @@ import tenacity
 from openhands.core.logger import openhands_logger as logger
 from openhands.storage.files import FileStore
 from openhands.utils.async_utils import EXECUTOR
+from openhands.utils.http_session import httpx_verify_option
 
 # Constants for batching configuration
 WEBHOOK_BATCH_TIMEOUT_SECONDS = 5.0
@@ -65,7 +66,7 @@ class BatchedWebHookFileStore(FileStore):
         self.file_store = file_store
         self.base_url = base_url
         if client is None:
-            client = httpx.Client()
+            client = httpx.Client(verify=httpx_verify_option())
         self.client = client
 
         # Use provided values or default constants

--- a/openhands/storage/web_hook.py
+++ b/openhands/storage/web_hook.py
@@ -3,6 +3,7 @@ import tenacity
 
 from openhands.storage.files import FileStore
 from openhands.utils.async_utils import EXECUTOR
+from openhands.utils.http_session import httpx_verify_option
 
 
 class WebHookFileStore(FileStore):
@@ -34,7 +35,7 @@ class WebHookFileStore(FileStore):
         self.file_store = file_store
         self.base_url = base_url
         if client is None:
-            client = httpx.Client()
+            client = httpx.Client(verify=httpx_verify_option())
         self.client = client
 
     def write(self, path: str, contents: str | bytes) -> None:

--- a/openhands/utils/http_session.py
+++ b/openhands/utils/http_session.py
@@ -23,6 +23,14 @@ _verify_certificates: bool = not _env_insecure_skip_verify()
 _client: httpx.Client | None = None
 
 
+def httpx_verify_option() -> ssl.SSLContext | bool:
+    """Return the verify option to pass when creating an HTTPX client."""
+
+    if _env_insecure_skip_verify():
+        return False
+    return ssl.create_default_context()
+
+
 def _build_client(verify: bool) -> httpx.Client:
     if verify:
         return httpx.Client(verify=ssl.create_default_context())


### PR DESCRIPTION
## Summary
- expose `httpx_verify_option` so callers can build HTTPX clients that respect the insecure verification environment override while relying on `ssl.create_default_context`
- update integrations, server routes, storage helpers, and runtimes that construct HTTPX clients directly to pass the shared verification option

## Testing
- `pytest tests/unit/integrations/github/test_github_service.py`