### PR TITLE
Ensure Bitbucket integration works with both server and cloud APIs

### DIFF
--- a/openhands/integrations/bitbucket/service/base.py
+++ b/openhands/integrations/bitbucket/service/base.py
@@ -136,7 +136,11 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
                         method=method,
                     )
                 response.raise_for_status()
-                return response.json(), dict(response.headers)
+                try:
+                    data = response.json()
+                except ValueError:
+                    data = response.text
+                return data, dict(response.headers)
         except httpx.HTTPStatusError as e:
             raise self.handle_http_status_error(e)
         except httpx.HTTPError as e:

--- a/openhands/integrations/bitbucket/service/branches.py
+++ b/openhands/integrations/bitbucket/service/branches.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from openhands.integrations.bitbucket.service.base import BitBucketMixinBase
 from openhands.integrations.service_types import Branch, PaginatedBranchesResponse
 
@@ -11,69 +13,62 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         """Get branches for a repository."""
         owner, repo = self._extract_owner_and_repo(repository)
 
-        url = f'{self.BASE_URL}/repositories/{owner}/{repo}/refs/branches'
+        url = f'{self._repo_api_base(owner, repo)}/branches'
 
         # Set maximum branches to fetch (similar to GitHub/GitLab implementations)
         MAX_BRANCHES = 1000
         PER_PAGE = 100
 
-        params = {
-            'pagelen': PER_PAGE,
-            'sort': '-target.date',  # Sort by most recent commit date, descending
-        }
+        if self._is_server:
+            params = {
+                'limit': PER_PAGE,
+                'orderBy': 'MODIFICATION',
+            }
+        else:
+            params = {
+                'pagelen': PER_PAGE,
+                'sort': '-target.date',  # Sort by most recent commit date, descending
+            }
 
         # Fetch all branches with pagination
         branch_data = await self._fetch_paginated_data(url, params, MAX_BRANCHES)
 
-        branches = []
-        for branch in branch_data:
-            branches.append(
-                Branch(
-                    name=branch.get('name', ''),
-                    commit_sha=branch.get('target', {}).get('hash', ''),
-                    protected=False,  # Bitbucket doesn't expose this in the API
-                    last_push_date=branch.get('target', {}).get('date', None),
-                )
-            )
-
-        return branches
+        return [self._parse_branch(branch) for branch in branch_data]
 
     async def get_paginated_branches(
         self, repository: str, page: int = 1, per_page: int = 30
     ) -> PaginatedBranchesResponse:
         """Get branches for a repository with pagination."""
         # Extract owner and repo from the repository string (e.g., "owner/repo")
-        parts = repository.split('/')
-        if len(parts) < 2:
-            raise ValueError(f'Invalid repository name: {repository}')
+        owner, repo = self._extract_owner_and_repo(repository)
 
-        owner = parts[-2]
-        repo = parts[-1]
+        url = f'{self._repo_api_base(owner, repo)}/branches'
 
-        url = f'{self.BASE_URL}/repositories/{owner}/{repo}/refs/branches'
-
-        params = {
-            'pagelen': per_page,
-            'page': page,
-            'sort': '-target.date',  # Sort by most recent commit date, descending
-        }
+        if self._is_server:
+            start = max((page - 1) * per_page, 0)
+            params = {
+                'limit': per_page,
+                'start': start,
+                'orderBy': 'MODIFICATION',
+            }
+        else:
+            params = {
+                'pagelen': per_page,
+                'page': page,
+                'sort': '-target.date',  # Sort by most recent commit date, descending
+            }
 
         response, _ = await self._make_request(url, params)
 
-        branches = []
-        for branch in response.get('values', []):
-            branches.append(
-                Branch(
-                    name=branch.get('name', ''),
-                    commit_sha=branch.get('target', {}).get('hash', ''),
-                    protected=False,  # Bitbucket doesn't expose this in the API
-                    last_push_date=branch.get('target', {}).get('date', None),
-                )
-            )
+        branches = [self._parse_branch(branch) for branch in response.get('values', [])]
 
         # Bitbucket provides pagination info in the response
-        has_next_page = response.get('next') is not None
-        total_count = response.get('size')  # Total number of items
+        if self._is_server:
+            has_next_page = not response.get('isLastPage', True)
+            total_count = response.get('size')
+        else:
+            has_next_page = response.get('next') is not None
+            total_count = response.get('size')  # Total number of items
 
         return PaginatedBranchesResponse(
             branches=branches,
@@ -87,30 +82,78 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         self, repository: str, query: str, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using Bitbucket API with `q` param."""
-        parts = repository.split('/')
-        if len(parts) < 2:
-            raise ValueError(f'Invalid repository name: {repository}')
+        owner, repo = self._extract_owner_and_repo(repository)
 
-        owner = parts[-2]
-        repo = parts[-1]
-
-        url = f'{self.BASE_URL}/repositories/{owner}/{repo}/refs/branches'
-        # Bitbucket filtering: name ~ "query"
-        params = {
-            'pagelen': per_page,
-            'q': f'name~"{query}"',
-            'sort': '-target.date',
-        }
+        url = f'{self._repo_api_base(owner, repo)}/branches'
+        if self._is_server:
+            params = {
+                'limit': per_page,
+                'filterText': query,
+                'orderBy': 'MODIFICATION',
+            }
+        else:
+            # Bitbucket filtering: name ~ "query"
+            params = {
+                'pagelen': per_page,
+                'q': f'name~"{query}"',
+                'sort': '-target.date',
+            }
         response, _ = await self._make_request(url, params)
 
-        branches: list[Branch] = []
-        for branch in response.get('values', []):
-            branches.append(
-                Branch(
-                    name=branch.get('name', ''),
-                    commit_sha=branch.get('target', {}).get('hash', ''),
-                    protected=False,
-                    last_push_date=branch.get('target', {}).get('date', None),
+        return [self._parse_branch(branch) for branch in response.get('values', [])]
+
+    def _parse_branch(self, branch: dict) -> Branch:
+        """Normalize Bitbucket branch representations across Cloud and Server."""
+
+        if self._is_server:
+            name = branch.get('displayId') or ''
+            if not name:
+                branch_id = branch.get('id', '')
+                if isinstance(branch_id, str) and branch_id.startswith('refs/heads/'):
+                    name = branch_id.split('refs/heads/', 1)[-1]
+                elif isinstance(branch_id, str):
+                    name = branch_id
+
+            commit_sha = branch.get('latestCommit', '')
+            last_push_date = self._extract_server_branch_last_modified(branch)
+        else:
+            name = branch.get('name', '')
+            target = branch.get('target', {}) or {}
+            commit_sha = target.get('hash', '')
+            last_push_date = target.get('date')
+
+        return Branch(
+            name=name,
+            commit_sha=commit_sha,
+            protected=False,  # Bitbucket doesn't expose branch protection via these endpoints
+            last_push_date=last_push_date,
+        )
+
+    def _extract_server_branch_last_modified(self, branch: dict) -> str | None:
+        """Extract the last modified timestamp from a Bitbucket Server branch payload."""
+
+        metadata = branch.get('metadata')
+        if not isinstance(metadata, dict):
+            return None
+
+        for value in metadata.values():
+            if not isinstance(value, list):
+                continue
+            for entry in value:
+                if not isinstance(entry, dict):
+                    continue
+                timestamp = (
+                    entry.get('authorTimestamp')
+                    or entry.get('committerTimestamp')
+                    or entry.get('timestamp')
+                    or entry.get('lastModified')
                 )
-            )
-        return branches
+                if isinstance(timestamp, (int, float)):
+                    return datetime.fromtimestamp(
+                        timestamp / 1000, tz=timezone.utc
+                    ).isoformat()
+                if isinstance(timestamp, str):
+                    # Some Bitbucket instances might already return ISO 8601 strings
+                    return timestamp
+
+        return None


### PR DESCRIPTION
## Summary
- allow Bitbucket requests to fall back to raw text responses so server file APIs can be parsed consistently
- update pull-request helpers to route to the correct Bitbucket Cloud and Server endpoints while extracting return URLs robustly
- adjust microagent content fetching and expand regression tests to cover server/cloud PR flows and file lookups

## Testing
- pytest tests/unit/integrations/bitbucket/test_bitbucket.py