### PR TITLE
Add optional tmp and shared memory volumes to Kubernetes runtime

### DIFF
--- a/openhands/core/config/kubernetes_config.py
+++ b/openhands/core/config/kubernetes_config.py
@@ -81,6 +81,23 @@ class KubernetesConfig(BaseModel):
         default=None,
         description='Override the primary group ID used for the runtime sandbox container',
     )
+    mount_tmp_empty_dir: bool = Field(
+        default=False,
+        description='Mount /tmp inside the runtime sandbox as an ephemeral emptyDir volume',
+    )
+    enable_memory_dshm_volume: bool = Field(
+        default=False,
+        description=(
+            'Mount /dev/shm as an in-memory emptyDir volume to increase shared memory capacity'
+        ),
+    )
+    memory_dshm_volume_size_limit: str | None = Field(
+        default=None,
+        description=(
+            'Optional size limit for the /dev/shm emptyDir volume (e.g. "1Gi"). Only applied when '
+            'enable_memory_dshm_volume is true.'
+        ),
+    )
 
     model_config = ConfigDict(extra='forbid')
 


### PR DESCRIPTION
## Summary
- add Kubernetes configuration flags to opt into mounting /tmp and /dev/shm emptyDir volumes
- mount the optional volumes in the Kubernetes runtime pod manifest, including optional size limits for the shared memory volume

## Testing
- PYTHONPATH=. pytest tests/runtime -k kubernetes

------
https://chatgpt.com/codex/tasks/task_e_68cf0f0f2b9c832ca4c2aafc98ca72f7